### PR TITLE
Disable some of the websocket testing

### DIFF
--- a/jmeter_files/daytrader10.jmx
+++ b/jmeter_files/daytrader10.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="DayTrader10" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -499,6 +499,7 @@
                       <stringProp name="connectTimeout">20000</stringProp>
                       <boolProp name="loadDataFromFile">false</boolProp>
                       <stringProp name="dataFile"></stringProp>
+                      <stringProp name="payloadType">Text</stringProp>
                     </eu.luminis.jmeter.wssampler.RequestResponseWebSocketSampler>
                     <hashTree>
                       <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
@@ -526,6 +527,7 @@
                       <stringProp name="connectTimeout">20000</stringProp>
                       <boolProp name="loadDataFromFile">false</boolProp>
                       <stringProp name="dataFile"></stringProp>
+                      <stringProp name="payloadType">Text</stringProp>
                     </eu.luminis.jmeter.wssampler.RequestResponseWebSocketSampler>
                     <hashTree>
                       <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
@@ -1535,7 +1537,7 @@
               </ConstantTimer>
               <hashTree/>
             </hashTree>
-            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If http" enabled="true">
+            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If http" enabled="false">
               <stringProp name="IfController.condition">${__jexl3(&quot;${protocol}&quot;== &quot;http&quot;,)}</stringProp>
               <boolProp name="IfController.evaluateAll">false</boolProp>
               <boolProp name="IfController.useExpression">true</boolProp>
@@ -1551,7 +1553,7 @@
               </eu.luminis.jmeter.wssampler.OpenWebSocketSampler>
               <hashTree/>
             </hashTree>
-            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If https" enabled="true">
+            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If https" enabled="false">
               <stringProp name="IfController.condition">${__jexl3(&quot;${protocol}&quot;== &quot;https&quot;,)}</stringProp>
               <boolProp name="IfController.evaluateAll">false</boolProp>
               <boolProp name="IfController.useExpression">true</boolProp>
@@ -1772,7 +1774,7 @@
                     <hashTree/>
                   </hashTree>
                 </hashTree>
-                <ThroughputController guiclass="ThroughputControllerGui" testclass="ThroughputController" testname="MarketSummary JSP" enabled="true">
+                <ThroughputController guiclass="ThroughputControllerGui" testclass="ThroughputController" testname="MarketSummary JSP" enabled="false">
                   <intProp name="ThroughputController.style">1</intProp>
                   <boolProp name="ThroughputController.perThread">true</boolProp>
                   <intProp name="ThroughputController.maxThroughput">1</intProp>
@@ -1796,6 +1798,7 @@
                     <stringProp name="connectTimeout">20000</stringProp>
                     <boolProp name="loadDataFromFile">false</boolProp>
                     <stringProp name="dataFile"></stringProp>
+                    <stringProp name="payloadType">Text</stringProp>
                   </eu.luminis.jmeter.wssampler.RequestResponseWebSocketSampler>
                   <hashTree>
                     <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">


### PR DESCRIPTION
The websocket client has not been behaving as expected, and is causing many connections to be opened/closed. Disabling some of the websocket testing (but not all) for now, while I figure out how to test this as expected. This change may be needed in daytrader 7, 8, and 9.