### PR TITLE
Add timeout for WS2

### DIFF
--- a/jmeter_files/README.txt
+++ b/jmeter_files/README.txt
@@ -13,7 +13,7 @@
  # limitations under the License.
  
 
-daytrader9.jmx is an Apache JMeter script that may be used for running the DayTrader9 benchmark.
+daytrader10.jmx is an Apache JMeter script that may be used for running the DayTrader10 benchmark.
 
 Jmeter version 3.3 or later is highly recommended.
 To use the script, you will need to put the the WebSocket Sampler (and dependencies) from WebSocket Samplers by Peter Doornbosch into lib/ext. 
@@ -31,6 +31,7 @@ The script has the following options:
 	-JSTOCKS    The total amount of stocks/quotes in the database, minus one. The default is 9999, which assumes there are 10,000 stocks in the database.
 	-JBOTUID    The lowest user id. The default is 0.
 	-JTOPUID    The highest user id. The default is 14999, which assumes there are 15,000 users in the database.
+        -JWEBSOCKET_TIMEOUT The amount of time to keep the websocket (WS2) open. The default is 60 seconds.
 	
 Example: ./jmeter -n -t daytrader9.jmx -JHOST=myserver -JPORT=9080 -JPROTOCOL=http -JMAXTHINKTIME=100 -JDURATION=300
 

--- a/jmeter_files/daytrader10.jmx
+++ b/jmeter_files/daytrader10.jmx
@@ -89,6 +89,11 @@
               <stringProp name="Argument.metadata">=</stringProp>
               <stringProp name="Argument.desc">http | https</stringProp>
             </elementProp>
+            <elementProp name="websocket_timeout" elementType="Argument">
+              <stringProp name="Argument.name">websocket_timeout</stringProp>
+              <stringProp name="Argument.value">${__P(WEBSOCKET_TIMEOUT,60)}</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
           </collectionProp>
         </Arguments>
         <hashTree/>
@@ -1468,6 +1473,128 @@
             </FloatProperty>
           </ThroughputController>
           <hashTree>
+            <OnceOnlyController guiclass="OnceOnlyControllerGui" testclass="OnceOnlyController" testname="Once Only Controller" enabled="true"/>
+            <hashTree>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If http" enabled="true">
+                <stringProp name="IfController.condition">${__jexl3(&quot;${protocol}&quot;== &quot;http&quot;,)}</stringProp>
+                <boolProp name="IfController.evaluateAll">false</boolProp>
+                <boolProp name="IfController.useExpression">true</boolProp>
+              </IfController>
+              <hashTree>
+                <eu.luminis.jmeter.wssampler.OpenWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.OpenWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.OpenWebSocketSampler" testname="WS2 Open Initial Connection http" enabled="true">
+                  <boolProp name="TLS">false</boolProp>
+                  <stringProp name="server">${hostname}</stringProp>
+                  <stringProp name="port">${port}</stringProp>
+                  <stringProp name="path">/daytrader/marketsummary</stringProp>
+                  <stringProp name="readTimeout">20000</stringProp>
+                  <stringProp name="connectTimeout">20000</stringProp>
+                </eu.luminis.jmeter.wssampler.OpenWebSocketSampler>
+                <hashTree/>
+              </hashTree>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If https" enabled="true">
+                <stringProp name="IfController.condition">${__jexl3(&quot;${protocol}&quot;== &quot;https&quot;,)}</stringProp>
+                <boolProp name="IfController.evaluateAll">false</boolProp>
+                <boolProp name="IfController.useExpression">true</boolProp>
+              </IfController>
+              <hashTree>
+                <eu.luminis.jmeter.wssampler.OpenWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.OpenWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.OpenWebSocketSampler" testname="WS2 Open Initial Connection https" enabled="true">
+                  <boolProp name="TLS">true</boolProp>
+                  <stringProp name="server">${hostname}</stringProp>
+                  <stringProp name="port">${port}</stringProp>
+                  <stringProp name="path">/daytrader/marketsummary</stringProp>
+                  <stringProp name="readTimeout">20000</stringProp>
+                  <stringProp name="connectTimeout">20000</stringProp>
+                </eu.luminis.jmeter.wssampler.OpenWebSocketSampler>
+                <hashTree/>
+              </hashTree>
+              <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="WS2 Set Initial Timeout" enabled="true">
+                <stringProp name="scriptLanguage">groovy</stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="script">def StartTime = new Date() 
+use(groovy.time.TimeCategory) {
+	def webSocketTimeout = vars.get(&quot;websocket_timeout&quot;) as Integer
+	def duration = new groovy.time.TimeDuration(0, 0, webSocketTimeout, 0) 
+   	def EndTime = StartTime + duration
+     vars.put(&quot;EndTime&quot;, EndTime.getTime() as String)
+     
+}</stringProp>
+              </JSR223Sampler>
+              <hashTree/>
+            </hashTree>
+            <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="WS2 Get Current Time" enabled="true">
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="script">def CurrentTime = new Date() 
+use(groovy.time.TimeCategory) {
+        vars.put(&quot;CurrentTime&quot;, CurrentTime.getTime() as String)
+
+         
+}</stringProp>
+              <stringProp name="scriptLanguage">groovy</stringProp>
+            </JSR223Sampler>
+            <hashTree/>
+            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Check Timeout" enabled="true">
+              <stringProp name="IfController.condition">${__groovy((vars.get(&apos;CurrentTime&apos;) as long) - (vars.get(&apos;EndTime&apos;) as long) &gt;= 0,)}</stringProp>
+              <boolProp name="IfController.evaluateAll">false</boolProp>
+              <boolProp name="IfController.useExpression">true</boolProp>
+            </IfController>
+            <hashTree>
+              <eu.luminis.jmeter.wssampler.CloseWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.CloseWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.CloseWebSocketSampler" testname="WS2 - WebSocket Close" enabled="true">
+                <stringProp name="statusCode">1000</stringProp>
+                <stringProp name="readTimeout">6000</stringProp>
+              </eu.luminis.jmeter.wssampler.CloseWebSocketSampler>
+              <hashTree/>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If http" enabled="true">
+                <stringProp name="IfController.condition">${__jexl3(&quot;${protocol}&quot;== &quot;http&quot;,)}</stringProp>
+                <boolProp name="IfController.evaluateAll">false</boolProp>
+                <boolProp name="IfController.useExpression">true</boolProp>
+              </IfController>
+              <hashTree>
+                <eu.luminis.jmeter.wssampler.OpenWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.OpenWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.OpenWebSocketSampler" testname="WS2 Open Connection http" enabled="true">
+                  <boolProp name="TLS">false</boolProp>
+                  <stringProp name="server">${hostname}</stringProp>
+                  <stringProp name="port">${port}</stringProp>
+                  <stringProp name="path">/daytrader/marketsummary</stringProp>
+                  <stringProp name="readTimeout">20000</stringProp>
+                  <stringProp name="connectTimeout">20000</stringProp>
+                </eu.luminis.jmeter.wssampler.OpenWebSocketSampler>
+                <hashTree/>
+              </hashTree>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If https" enabled="true">
+                <stringProp name="IfController.condition">${__jexl3(&quot;${protocol}&quot;== &quot;https&quot;,)}</stringProp>
+                <boolProp name="IfController.evaluateAll">false</boolProp>
+                <boolProp name="IfController.useExpression">true</boolProp>
+              </IfController>
+              <hashTree>
+                <eu.luminis.jmeter.wssampler.OpenWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.OpenWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.OpenWebSocketSampler" testname="WS2 Open Connection https" enabled="true">
+                  <boolProp name="TLS">true</boolProp>
+                  <stringProp name="server">${hostname}</stringProp>
+                  <stringProp name="port">${port}</stringProp>
+                  <stringProp name="path">/daytrader/marketsummary</stringProp>
+                  <stringProp name="readTimeout">20000</stringProp>
+                  <stringProp name="connectTimeout">20000</stringProp>
+                </eu.luminis.jmeter.wssampler.OpenWebSocketSampler>
+                <hashTree/>
+              </hashTree>
+              <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="WS2 Set Timeout" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">def StartTime = new Date() 
+use(groovy.time.TimeCategory) {
+	def webSocketTimeout = vars.get(&quot;websocket_timeout&quot;) as Integer
+	def duration = new groovy.time.TimeDuration(0, 0, webSocketTimeout, 0) 
+   	def EndTime = StartTime + duration
+     vars.put(&quot;EndTime&quot;, EndTime.getTime() as String)
+     
+}</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223Sampler>
+              <hashTree/>
+            </hashTree>
             <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Login" enabled="true">
               <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
                 <collectionProp name="Arguments.arguments">
@@ -1535,38 +1662,6 @@
               <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
                 <stringProp name="ConstantTimer.delay">${maxthinkingtime}</stringProp>
               </ConstantTimer>
-              <hashTree/>
-            </hashTree>
-            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If http" enabled="false">
-              <stringProp name="IfController.condition">${__jexl3(&quot;${protocol}&quot;== &quot;http&quot;,)}</stringProp>
-              <boolProp name="IfController.evaluateAll">false</boolProp>
-              <boolProp name="IfController.useExpression">true</boolProp>
-            </IfController>
-            <hashTree>
-              <eu.luminis.jmeter.wssampler.OpenWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.OpenWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.OpenWebSocketSampler" testname="WS2 Open Connection http" enabled="true">
-                <boolProp name="TLS">false</boolProp>
-                <stringProp name="server">${hostname}</stringProp>
-                <stringProp name="port">${port}</stringProp>
-                <stringProp name="path">/daytrader/marketsummary</stringProp>
-                <stringProp name="readTimeout">20000</stringProp>
-                <stringProp name="connectTimeout">20000</stringProp>
-              </eu.luminis.jmeter.wssampler.OpenWebSocketSampler>
-              <hashTree/>
-            </hashTree>
-            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If https" enabled="false">
-              <stringProp name="IfController.condition">${__jexl3(&quot;${protocol}&quot;== &quot;https&quot;,)}</stringProp>
-              <boolProp name="IfController.evaluateAll">false</boolProp>
-              <boolProp name="IfController.useExpression">true</boolProp>
-            </IfController>
-            <hashTree>
-              <eu.luminis.jmeter.wssampler.OpenWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.OpenWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.OpenWebSocketSampler" testname="WS2 Open Connection https" enabled="true">
-                <boolProp name="TLS">true</boolProp>
-                <stringProp name="server">${hostname}</stringProp>
-                <stringProp name="port">${port}</stringProp>
-                <stringProp name="path">/daytrader/marketsummary</stringProp>
-                <stringProp name="readTimeout">20000</stringProp>
-                <stringProp name="connectTimeout">20000</stringProp>
-              </eu.luminis.jmeter.wssampler.OpenWebSocketSampler>
               <hashTree/>
             </hashTree>
             <WhileController guiclass="WhileControllerGui" testclass="WhileController" testname="While Controller" enabled="true">
@@ -1774,7 +1869,7 @@
                     <hashTree/>
                   </hashTree>
                 </hashTree>
-                <ThroughputController guiclass="ThroughputControllerGui" testclass="ThroughputController" testname="MarketSummary JSP" enabled="false">
+                <ThroughputController guiclass="ThroughputControllerGui" testclass="ThroughputController" testname="MarketSummary JSP" enabled="true">
                   <intProp name="ThroughputController.style">1</intProp>
                   <boolProp name="ThroughputController.perThread">true</boolProp>
                   <intProp name="ThroughputController.maxThroughput">1</intProp>
@@ -2438,11 +2533,6 @@
                 </hashTree>
               </hashTree>
             </hashTree>
-            <eu.luminis.jmeter.wssampler.CloseWebSocketSampler guiclass="eu.luminis.jmeter.wssampler.CloseWebSocketSamplerGui" testclass="eu.luminis.jmeter.wssampler.CloseWebSocketSampler" testname="WebSocket Close" enabled="false">
-              <stringProp name="statusCode">4000</stringProp>
-              <stringProp name="readTimeout">6000</stringProp>
-            </eu.luminis.jmeter.wssampler.CloseWebSocketSampler>
-            <hashTree/>
           </hashTree>
           <ThroughputController guiclass="ThroughputControllerGui" testclass="ThroughputController" testname="Throughput Controller JAX-RS" enabled="true">
             <intProp name="ThroughputController.style">1</intProp>


### PR DESCRIPTION
Re-enabling the webscket testing, but with a timeout setting (default is 60 seconds).
```
-JWEBSOCKET_TIMEOUT=60
```